### PR TITLE
README.md: Add note about GO111MODULE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Install Go language (golang), guidelines at:
   * https://golang.org
   * https://golang.org/doc/install
 
+**Note**: When using Go version 1.16 or later, it's necessary to set the environment variable `GO111MODULE` to `off` prior to executing the `go get` or `make` commands below. When using an `sh`-compatible shell, this can be accomplished with `export GO111MODULE=off`
+
+***
+
 Deploy the `secsipidx` tool with:
 
 ```


### PR DESCRIPTION
Minor documentation update add the requirement for setting `GO111MODULE` to `off` with recent Go versions.

As I am not very familiar with Go, this may not be the correct approach. I'm providing this solution in case it may be useful.

Closes #10