### PR TITLE
Use the -x5u value as the default when signing

### DIFF
--- a/main.go
+++ b/main.go
@@ -465,6 +465,9 @@ func main() {
 	if cliops.certverify > 0 {
 		secsipid.SJWTLibOptSetN("CertVerify", cliops.certverify)
 	}
+	if len(cliops.x5u) > 0 {
+		secsipid.SJWTLibOptSetS("x5u", cliops.x5u)
+	}
 
 	if (len(cliops.httpsrv) > 0) || (len(cliops.httpssrv) > 0 && len(cliops.httpspubkey) > 0 && len(cliops.httpsprvkey) > 0) {
 		http.HandleFunc("/v1/check", httpHandleV1Check)

--- a/secsipid/secsipid.go
+++ b/secsipid/secsipid.go
@@ -106,6 +106,7 @@ type SJWTLibOptions struct {
 	certCAInter  string
 	certCRLFile  string
 	certVerify   int
+	x5u          string
 }
 
 var globalLibOptions = SJWTLibOptions{
@@ -115,6 +116,7 @@ var globalLibOptions = SJWTLibOptions{
 	certCAInter:  "",
 	certCRLFile:  "",
 	certVerify:   0,
+	x5u:          "https://127.0.0.1/cert.pem",
 }
 
 var (
@@ -142,6 +144,9 @@ func SJWTLibOptSetS(optname string, optval string) int {
 		return SJWTRetOK
 	case "CertCAInter":
 		globalLibOptions.certCAInter = optval
+		return SJWTRetOK
+	case "x5u":
+		globalLibOptions.x5u = optval
 		return SJWTRetOK
 	}
 	return SJWTRetErr
@@ -901,7 +906,7 @@ func SJWTGetIdentityPrvKey(origTN string, destTN string, attestVal string, origI
 		Alg: "ES256",
 		Ppt: "shaken",
 		Typ: "passport",
-		X5u: "https://127.0.0.1/cert.pem",
+		X5u: globalLibOptions.x5u,
 	}
 	if len(x5uVal) > 0 {
 		header.X5u = x5uVal


### PR DESCRIPTION
@miconda this change will use the value of the -x5u CLI parameter as the default value when signing identity headers. This way the default can be configured/managed on the web server and client applications can just submit an empty string for the x5u parameter.

```
curl --data '12015551234,12015559876,A,,' https://sti.example.com/v1/sign-csv
```