### PR TITLE
csecsipid/Makefile: use proper variable defined at Makefile.defs

### DIFF
--- a/csecsipid/Makefile
+++ b/csecsipid/Makefile
@@ -4,7 +4,7 @@
 include ../Makefile.defs
 
 SOBASENAME=libsecsipid.so
-SOLIBNAME=${SOBASENAME}.${LIBVERSIONMAJOR}
+SOLIBNAME=${SOBASENAME}.${LIBVERMAJ}
 SOREALNAME=${SOBASENAME}.${LIBVERSION}
 
 ifneq ($(OS), darwin)


### PR DESCRIPTION
While packaging 1.3.2 version I noticed:

> make[3]: Entering directory '/build/secsipidx-1.3.2/_build/src/github.com/asipto/secsipidx/csecsipid' 
> rm -rf libsecsipid.so.
> rm -rf libsecsipid.so
> rm -rf libsecsipid.so.1.3.2

And:

> lrwxrwxrwx root/root         0 2023-11-17 13:23 ./usr/lib/x86_64-linux-gnu/libsecsipid.so. -> libsecsipid.so.1.3.2