### PR TITLE
test: avoid conversion failing on some architectures

### DIFF
--- a/secsipid/url_cache_test.go
+++ b/secsipid/url_cache_test.go
@@ -71,7 +71,7 @@ func TestGetURLContent(t *testing.T) {
 
 	t.Run("OK with cached value", func(t *testing.T) {
 		workDir, _ := os.Getwd()
-		secsipid.SetURLFileCacheOptions(workDir, int(time.Hour))
+		secsipid.SetURLFileCacheOptions(workDir, 3600)
 		os.WriteFile("http_example.com_foo", []byte("Hello, world"), 0777)
 
 		runTest(t, GetURLValueTest{
@@ -88,7 +88,7 @@ func TestGetURLContent(t *testing.T) {
 
 	t.Run("ErrHTTPGet with no cache file and no running server", func(t *testing.T) {
 		workDir, _ := os.Getwd()
-		secsipid.SetURLFileCacheOptions(workDir, int(time.Hour))
+		secsipid.SetURLFileCacheOptions(workDir, 3600)
 		defer secsipid.SetURLFileCacheOptions("", 0)
 
 		runTest(t, GetURLValueTest{
@@ -188,7 +188,7 @@ func TestGetURLContent(t *testing.T) {
 
 	t.Run("OK and caches if cacheDirPath is set", func(t *testing.T) {
 		workDir, _ := os.Getwd()
-		secsipid.SetURLFileCacheOptions(workDir, int(time.Hour))
+		secsipid.SetURLFileCacheOptions(workDir, 3600)
 
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Write([]byte("Hello from the server!"))


### PR DESCRIPTION
expires parameter is seconds but time.Hour is:

> const (
> 	Nanosecond  Duration = 1
> 	Microsecond          = 1000 * Nanosecond
> 	Millisecond          = 1000 * Microsecond
> 	Second               = 1000 * Millisecond
> 	Minute               = 60 * Second
> 	Hour                 = 60 * Minute
> )

Builds on armel, armhf and i386 failing due to:

> github.com/asipto/secsipidx/secsipid_test [github.com/asipto/secsipidx/secsipid.test]
> src/github.com/asipto/secsipidx/secsipid/url_cache_test.go:74:48: cannot convert time.Hour (constant 3600000000000 of type time.Duration) to type int
> src/github.com/asipto/secsipidx/secsipid/url_cache_test.go:91:48: cannot convert time.Hour (constant 3600000000000 of type time.Duration) to type int
> src/github.com/asipto/secsipidx/secsipid/url_cache_test.go:191:48: cannot convert time.Hour (constant 3600000000000 of type time.Duration) to type int