### PR TITLE
verify time validity only with --cert-verify=1

### DIFF
--- a/secsipid/secsipid.go
+++ b/secsipid/secsipid.go
@@ -270,6 +270,10 @@ func SJWTPubKeyVerify(pubKey []byte) (int, error) {
 			return SJWTRetErrCertBeforeValidity, errors.New("certificate not valid yet")
 		}
 	}
+	// verify time validity only
+	if globalLibOptions.certVerify == 1 {
+		return SJWTRetOK, nil
+	}
 
 	rootCAs = nil
 	interCAs = nil


### PR DESCRIPTION
Hi @miconda thank again for your useful stuff, 

**When I run below command to verify time validity**:
`secsipidx -check -fidentity libre.identity -fpubkey libre.cer -expire 1000000 -ca-file rootca.cer --crl-file crl --cert-verify 1 `

**then output**
```shell
error message: x509: “SHAKEN FRTE00” certificate is not trusted
not-ok
```
This error happen because of later validation

Since README document mention
>  * `1` (`1<<0`) - verify time validity (not expired and not before validity date)

In my opinion, this error should not happen, cause user only want to `verify time validity`

So, I created simple pull request for correct it as document, could you please take time to review. Thanks.

