### PR TITLE
Default to using the info parameter of the Identity header

### DIFF
--- a/main.go
+++ b/main.go
@@ -344,10 +344,6 @@ func secsipidxCLICheck() int {
 	var ret int
 	var err error
 
-	if len(cliops.fpubkey) <= 0 {
-		fmt.Printf("path to public key not provided\n")
-		return -1
-	}
 	if len(cliops.fidentity) > 0 {
 		vIdentity, _ := ioutil.ReadFile(cliops.fidentity)
 		sIdentity = string(vIdentity)


### PR DESCRIPTION
This is a proposal to modify the default behavior of `-check` to use the URL from the info part of the header if `-fpubkey` isn't provided. This will allow the underlying function `SJWTCheckFullIdentity` to call `SJWTCheckFullIdentityURL` without having to implement another flag to do so.